### PR TITLE
add standardized usage tracking to all API responses (closes #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.3.1] - 2026-03-31
+
+### Added
+- Extended cache fields in `parse_usage`: `cache_ephemeral_1h_tokens`, `cache_ephemeral_5m_tokens`, `cache_deleted_tokens` from Anthropic's `cache_creation` nested object
+- `count_tokens` now returns `:usage` key with standardized usage hash
+- SSE `collect_usage` returns full 7-field usage hash including cache tokens from stream events
+
+### Changed
+- `parse_usage` refactored to use `uval` helper for dual string/symbol key access
+- SSE `collect_usage` uses `merge_usage` to generically accumulate all usage fields including nested `cache_creation`
+
 ## [0.3.0] - 2026-03-31
 
 ### Added

--- a/lib/legion/extensions/claude/helpers/response.rb
+++ b/lib/legion/extensions/claude/helpers/response.rb
@@ -47,12 +47,22 @@ module Legion
 
           def parse_usage(body)
             usage = body.is_a?(Hash) ? (body[:usage] || body['usage'] || {}) : {} # rubocop:disable Legion/Framework/ApiStringKeys
+            cache_creation = usage.is_a?(Hash) ? (usage[:cache_creation] || usage['cache_creation'] || {}) : {}
             {
-              input_tokens:       (usage[:input_tokens] || usage['input_tokens'] || 0).to_i,
-              output_tokens:      (usage[:output_tokens] || usage['output_tokens'] || 0).to_i,
-              cache_read_tokens:  (usage[:cache_read_input_tokens] || usage['cache_read_input_tokens'] || 0).to_i,
-              cache_write_tokens: (usage[:cache_creation_input_tokens] || usage['cache_creation_input_tokens'] || 0).to_i
+              input_tokens:              uval(usage, :input_tokens),
+              output_tokens:             uval(usage, :output_tokens),
+              cache_read_tokens:         uval(usage, :cache_read_input_tokens),
+              cache_write_tokens:        uval(usage, :cache_creation_input_tokens),
+              cache_ephemeral_1h_tokens: uval(cache_creation, :ephemeral_1h_input_tokens),
+              cache_ephemeral_5m_tokens: uval(cache_creation, :ephemeral_5m_input_tokens),
+              cache_deleted_tokens:      uval(usage, :cache_deleted_input_tokens)
             }
+          end
+
+          def uval(hash, key)
+            return 0 unless hash.is_a?(Hash)
+
+            (hash[key] || hash[key.to_s] || 0).to_i
           end
         end
       end

--- a/lib/legion/extensions/claude/helpers/sse.rb
+++ b/lib/legion/extensions/claude/helpers/sse.rb
@@ -45,22 +45,38 @@ module Legion
           end
 
           def collect_usage(events)
-            input_tokens  = 0
-            output_tokens = 0
+            totals = Hash.new(0)
 
             events.each do |e|
               case e[:event]
               when 'message_start'
-                usage = e[:data].dig('message', 'usage') || {}
-                input_tokens  += usage.fetch('input_tokens', 0).to_i
-                output_tokens += usage.fetch('output_tokens', 0).to_i
+                merge_usage(totals, e[:data].dig('message', 'usage'))
               when 'message_delta'
-                usage = e[:data].fetch('usage', {})
-                output_tokens += usage.fetch('output_tokens', 0).to_i
+                merge_usage(totals, e[:data]['usage'])
               end
             end
 
-            { input_tokens: input_tokens, output_tokens: output_tokens }
+            {
+              input_tokens:              totals['input_tokens'],
+              output_tokens:             totals['output_tokens'],
+              cache_read_tokens:         totals['cache_read_input_tokens'],
+              cache_write_tokens:        totals['cache_creation_input_tokens'],
+              cache_ephemeral_1h_tokens: totals['ephemeral_1h_input_tokens'],
+              cache_ephemeral_5m_tokens: totals['ephemeral_5m_input_tokens'],
+              cache_deleted_tokens:      totals['cache_deleted_input_tokens']
+            }
+          end
+
+          def merge_usage(totals, usage)
+            return unless usage.is_a?(Hash)
+
+            usage.each do |key, val|
+              if val.is_a?(Hash)
+                val.each { |k, v| totals[k.to_s] += v.to_i }
+              else
+                totals[key.to_s] += val.to_i
+              end
+            end
           end
         end
       end

--- a/lib/legion/extensions/claude/runners/messages.rb
+++ b/lib/legion/extensions/claude/runners/messages.rb
@@ -61,7 +61,9 @@ module Legion
             resolved_betas << :interleaved_thinking if thinking && !resolved_betas.include?(:interleaved_thinking)
 
             response = client(api_key: api_key, betas: resolved_betas).post('/v1/messages/count_tokens', body)
-            Helpers::Response.handle_response(response)
+            result = Helpers::Response.handle_response(response)
+            result[:usage] = Helpers::Response.parse_usage(response.body) if response.body.is_a?(Hash)
+            result
           end
 
           private

--- a/lib/legion/extensions/claude/version.rb
+++ b/lib/legion/extensions/claude/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Claude
-      VERSION = '0.3.0'
+      VERSION = '0.3.1'
     end
   end
 end

--- a/spec/legion/extensions/claude/helpers/response_spec.rb
+++ b/spec/legion/extensions/claude/helpers/response_spec.rb
@@ -120,5 +120,31 @@ RSpec.describe Legion::Extensions::Claude::Helpers::Response do
       expect(usage[:input_tokens]).to eq(0)
       expect(usage[:output_tokens]).to eq(0)
     end
+
+    it 'parses extended cache fields' do
+      body = {
+        'usage' => {
+          'input_tokens'               => 10,
+          'output_tokens'              => 20,
+          'cache_deleted_input_tokens' => 50,
+          'cache_creation'             => {
+            'ephemeral_1h_input_tokens' => 100,
+            'ephemeral_5m_input_tokens' => 200
+          }
+        }
+      }
+      usage = mod.parse_usage(body)
+      expect(usage[:cache_ephemeral_1h_tokens]).to eq(100)
+      expect(usage[:cache_ephemeral_5m_tokens]).to eq(200)
+      expect(usage[:cache_deleted_tokens]).to eq(50)
+    end
+
+    it 'defaults extended cache fields to zero when absent' do
+      body = { 'usage' => { 'input_tokens' => 5, 'output_tokens' => 3 } }
+      usage = mod.parse_usage(body)
+      expect(usage[:cache_ephemeral_1h_tokens]).to eq(0)
+      expect(usage[:cache_ephemeral_5m_tokens]).to eq(0)
+      expect(usage[:cache_deleted_tokens]).to eq(0)
+    end
   end
 end

--- a/spec/legion/extensions/claude/helpers/sse_spec.rb
+++ b/spec/legion/extensions/claude/helpers/sse_spec.rb
@@ -79,5 +79,35 @@ RSpec.describe Legion::Extensions::Claude::Helpers::Sse do
       expect(usage[:input_tokens]).to eq(10)
       expect(usage[:output_tokens]).to eq(5)
     end
+
+    it 'includes cache tokens when present in stream' do
+      cached_stream = <<~SSE
+        event: message_start
+        data: {"type":"message_start","message":{"id":"msg_c","usage":{"input_tokens":8,"output_tokens":0,"cache_read_input_tokens":500,"cache_creation_input_tokens":200}}}
+
+        event: message_delta
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":10}}
+
+        event: message_stop
+        data: {"type":"message_stop"}
+
+      SSE
+      events = mod.parse_stream(cached_stream)
+      usage  = mod.collect_usage(events)
+      expect(usage[:input_tokens]).to eq(8)
+      expect(usage[:output_tokens]).to eq(10)
+      expect(usage[:cache_read_tokens]).to eq(500)
+      expect(usage[:cache_write_tokens]).to eq(200)
+    end
+
+    it 'defaults cache fields to zero when absent' do
+      events = mod.parse_stream(sample_stream)
+      usage  = mod.collect_usage(events)
+      expect(usage[:cache_read_tokens]).to eq(0)
+      expect(usage[:cache_write_tokens]).to eq(0)
+      expect(usage[:cache_ephemeral_1h_tokens]).to eq(0)
+      expect(usage[:cache_ephemeral_5m_tokens]).to eq(0)
+      expect(usage[:cache_deleted_tokens]).to eq(0)
+    end
   end
 end

--- a/spec/legion/extensions/claude/runners/messages_spec.rb
+++ b/spec/legion/extensions/claude/runners/messages_spec.rb
@@ -233,6 +233,17 @@ RSpec.describe Legion::Extensions::Claude::Runners::Messages do
       expect(result[:result]['input_tokens']).to eq(42)
     end
 
+    it 'includes usage in count_tokens response' do
+      resp = instance_double(Faraday::Response,
+                             body:    { 'input_tokens' => 42, 'usage' => { 'input_tokens' => 42 } },
+                             status:  200,
+                             headers: {})
+      allow(faraday_conn).to receive(:post).with('/v1/messages/count_tokens', anything).and_return(resp)
+
+      result = instance.count_tokens(api_key: api_key, model: model, messages: messages)
+      expect(result[:usage][:input_tokens]).to eq(42)
+    end
+
     it 'includes thinking in count_tokens body when provided' do
       thinking = { type: 'enabled', budget_tokens: 2000 }
       allow(faraday_conn).to receive(:post)


### PR DESCRIPTION
## Summary
- Extend `parse_usage` with 3 new Anthropic cache fields: `cache_ephemeral_1h_tokens`, `cache_ephemeral_5m_tokens`, `cache_deleted_tokens` (from nested `cache_creation` object)
- `count_tokens` now returns `:usage` key with the same standardized hash as `create` and `create_stream`
- SSE `collect_usage` upgraded from 2-field to 7-field usage hash, capturing cache tokens from stream events
- Refactored to `uval` helper (dual string/symbol key access) and `merge_usage` (generic accumulator)

Closes #2

## Test plan
- [x] 121 examples, 0 failures (5 new specs)
- [x] 0 rubocop offenses
- [ ] Verify cache token fields populate correctly with prompt caching enabled