### PR TITLE
add server-side context_management beta support (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.2] - 2026-03-31
+
+### Added
+- Specs for `context_management` beta support in `Runners::Messages#create` and `#create_stream`: body inclusion, beta header auto-injection (`context-management-2025-06-27`), and nil omission
+
 ## [0.3.1] - 2026-03-31
 
 ### Added

--- a/lib/legion/extensions/claude/version.rb
+++ b/lib/legion/extensions/claude/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Claude
-      VERSION = '0.3.1'
+      VERSION = '0.3.2'
     end
   end
 end

--- a/spec/legion/extensions/claude/runners/messages_spec.rb
+++ b/spec/legion/extensions/claude/runners/messages_spec.rb
@@ -158,6 +158,65 @@ RSpec.describe Legion::Extensions::Claude::Runners::Messages do
 
       instance.create(api_key: api_key, model: model, messages: messages, metadata: meta)
     end
+
+    context 'with context_management' do
+      let(:context_management_payload) do
+        {
+          edits: [
+            {
+              type:           'clear_tool_uses_20250919',
+              trigger:        { input_tokens: 180_000 },
+              keep:           { tail_tokens: 40_000 },
+              clear_at_least: 140_000,
+              tool_config:    {
+                clear_tool_inputs: %w[Read Bash Grep Glob WebFetch],
+                exclude_tools:     %w[Write Edit]
+              }
+            },
+            {
+              type: 'clear_thinking_20251015'
+            }
+          ]
+        }
+      end
+
+      it 'sends context_management in the request body' do
+        allow(faraday_conn).to receive(:post)
+          .with('/v1/messages', hash_including(context_management: context_management_payload))
+          .and_return(success_response)
+
+        result = instance.create(api_key: api_key, model: model, messages: messages,
+                                 context_management: context_management_payload)
+
+        expect(result[:status]).to eq(200)
+      end
+
+      it 'auto-injects the context-management-2025-06-27 beta header' do
+        captured_betas = nil
+        allow(Faraday).to receive(:new) do |**_kwargs, &blk|
+          headers = {}
+          conn = instance_double(Faraday::Connection, headers: headers, request: nil, response: nil)
+          allow(conn).to receive(:post).and_return(success_response)
+          blk&.call(conn)
+          captured_betas = headers['anthropic-beta']
+          conn
+        end
+
+        instance.create(api_key: api_key, model: model, messages: messages,
+                        context_management: context_management_payload)
+
+        expect(captured_betas).to include('context-management-2025-06-27')
+      end
+
+      it 'omits context_management from body when nil' do
+        allow(faraday_conn).to receive(:post) do |_path, body|
+          expect(body).not_to have_key(:context_management)
+          success_response
+        end
+
+        instance.create(api_key: api_key, model: model, messages: messages)
+      end
+    end
   end
 
   describe '#create_stream' do
@@ -216,6 +275,18 @@ RSpec.describe Legion::Extensions::Claude::Runners::Messages do
       end
       expect(deltas.length).to eq(1)
       expect(deltas.first[:data]['delta']['text']).to eq('Hi!')
+    end
+
+    it 'includes context_management in the body when provided' do
+      cm = { edits: [{ type: 'clear_thinking_20251015' }] }
+      allow(faraday_conn).to receive(:post) do |_path, body|
+        parsed = MultiJson.load(body, symbolize_keys: true)
+        expect(parsed[:context_management]).to eq(cm)
+        stream_response
+      end
+
+      instance.create_stream(api_key: api_key, model: model, messages: messages,
+                             context_management: cm)
     end
   end
 


### PR DESCRIPTION
## Summary

- Adds specs for `context_management` beta parameter support in `Runners::Messages#create` and `#create_stream`
- Verifies the `context-management-2025-06-27` beta header is auto-injected when `context_management` is present
- Verifies the payload is included in the request body verbatim
- Verifies `context_management` is omitted from the body when `nil`
- Bumps version to 0.3.2

## Test plan

- [ ] `bundle exec rspec` — 125 examples, 0 failures
- [ ] `bundle exec rubocop` — 28 files inspected, no offenses
- [ ] New `context_management` context in `messages_spec.rb` covers: body inclusion, beta header injection, nil omission
- [ ] `create_stream` with `context_management` verifies the serialized body contains the payload

Closes #5